### PR TITLE
Assult

### DIFF
--- a/ERATANKdnc.html
+++ b/ERATANKdnc.html
@@ -11,8 +11,9 @@
     <script src="GameObjControl.js" type="text/javascript"></script>
     <script src="GameObjMine.js"    type="text/javascript"></script>
     <script src="StageControl.js"   type="text/javascript"></script>
-    <script src="spriteControl2.js"   type="text/javascript"></script>
-    <script src="viewport.js"   type="text/javascript"></script>        
+    <script src="spriteControl2.js" type="text/javascript"></script>
+    <script src="offScreenTypeC.js" type="text/javascript"></script>        
+    <script src="viewport.js"       type="text/javascript"></script>        
     <script type="text/javascript">
         function autorun(){
             document.getElementById("layer0").style.display = "none";

--- a/ERATANKdnc.html
+++ b/ERATANKdnc.html
@@ -8,6 +8,7 @@
     <script src="GameTaskMain.js"   type="text/javascript"></script>
     <script src="GameScene.js"      type="text/javascript"></script>
     <script src="SceneCollection.js" type="text/javascript"></script>
+    <script src="GameObjPlayer.js" type="text/javascript"></script>
     <script src="GameObjControl.js" type="text/javascript"></script>
     <script src="GameObjMine.js"    type="text/javascript"></script>
     <script src="StageControl.js"   type="text/javascript"></script>

--- a/GameObjControl.js
+++ b/GameObjControl.js
@@ -302,6 +302,7 @@ function GameObject(){
         }
 
         //g.viewport.setPos(Math.trunc(this.x-320), Math.trunc(this.y-240));
+        g.screen[0].buffer.turn(360 - this.turlet.vector());
     }
     
     this.draw = function(g){

--- a/GameObjPlayer.js
+++ b/GameObjPlayer.js
@@ -1,0 +1,427 @@
+function GameObjectPlayer(){
+
+    const RESO_X = 640;
+	const RESO_Y = 480;
+
+    this.r = 0;
+    this.vr = 0;
+    this.x = 0;
+    this.y = 0;
+
+    this.old_X = 0;
+    this.old_y = 0;
+
+    this.triggerDelay = 0;
+	this.op = { ptr: 0, x: Array(40), y: Array(40), r: Array(40)};
+    this.turlet = new turlet_vec_check();
+
+    let MyTurlet;
+    let Friend;
+    let FriendT;
+    let ArmorF;
+    let ArmorL;
+    let ArmorR;
+
+    let status = {speed:0, charge:0, power:0 };
+
+    this.spriteItem;
+
+    let reexf;
+    let blmode = false;
+
+    let note;
+    let notescore;
+    let notetime;
+
+    function turlet_vec_check(){
+		let turlet = 0;
+
+        this.vecToR = function(wx, wy){
+			let r = (wx == 0)?
+			((wy >= 0)?180: 0):
+			((Math.atan(wy / wx) * (180.0 / Math.PI)) + ((wx >= 0)? 90:270))
+			
+			return (270+r)%360;
+		}
+
+        this.check = function(r){
+			let wr = Math.trunc(180 + r - turlet)%360;
+			if (wr >= 180) turlet++;
+			if (wr <= 180) turlet--;
+			if (wr >= 210) turlet+=3;
+			if (wr <= 150) turlet-=3;
+			if (wr >= 270) turlet+=3;
+			if (wr <=  90) turlet-=3;
+		}
+
+        this.move = function(vr){
+            turlet = (turlet + vr)%360;
+        }
+
+        this.vector = function(){
+            return turlet;//turVector[turlet];
+        }
+    }
+    this.init = function(g){
+
+        this.r = 0;
+        this.vr = 0;
+        this.x =  this.spriteItem.x;
+        this.y =  this.spriteItem.y;
+        this.old_x = this.x;
+        this.old_y = this.y;
+        this.triggerDelay = 0;
+        this.op.ptr = 0;
+        this.op.x.fill(this.x);
+        this.op.y.fill(this.y);
+        this.op.r.fill(0);
+
+        this.spriteItem.mode = 0;
+        this.spriteItem.linkedOption = false;
+        
+        MyTurlet = {sp:g.sprite.itemCreate("Turlet", false, 32, 32) , re:false};
+        MyTurlet.sp.customDraw = customDraw_turlet;
+        MyTurlet.sp.priority = 1;
+
+        Friend = {sp:g.sprite.itemCreate("FRIEND_P", true, 32, 32) , re:false};
+        FriendT = {sp:g.sprite.itemCreate("Turlet", false, 32, 32) , re:false};
+        ArmorF = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+        ArmorL = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+        ArmorR = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+
+        reexf = false;
+        blmode = false;
+
+        Friend.sp.dispose(); Friend.re = true; 
+        FriendT.sp.dispose(); FriendT.re = true;
+        ArmorF.sp.dispose(); ArmorF.re = true;
+        ArmorL.sp.dispose(); ArmorL.re = true;
+        ArmorR.sp.dispose(); ArmorR.re = true;
+
+        notescore = g.beep.makeScore(["C2"], 250, 0.3);
+    }
+
+    this.setNote = function(n){
+        note = n;
+        notetime = 0;
+    }
+  
+    this.step = function(g, input, result){
+        this.spriteItem.collisionEnable = (result.clrf)?false:true;
+
+        let x = input.x;
+        let y = input.y;
+        let trigger = input.trigger;
+        let lock = (input.left || input.right)?true:false;
+
+        if (trigger) {
+            if (this.triggerDelay < g.time()){
+                this.triggerDelay = g.time()+250;
+
+                let sp = g.sprite.itemCreate(((blmode)?"BULLET_P2":"BULLET_P"), true, 8, 8);
+
+                let r =  this.turlet.vector();
+                let px = this.x + Math.cos((Math.PI/180)*r)*16
+                let py = this.y + Math.sin((Math.PI/180)*r)*16 
+
+                sp.pos(px, py, 0, 0.6 );
+                sp.move((r+90)% 360, 6, 120);// number, r, speed, lifetime//3kf 5min
+
+                if (Friend.sp.living){
+                    op = this.op;
+                    sp = g.sprite.itemCreate("BULLET_P3", true, 8, 8);
+                    sp.pos(op.x[(op.ptr) % op.x.length], op.y[(op.ptr) % op.x.length], 0, 0.6 );
+                    sp.move((op.r[(op.ptr) % op.x.length]+90)% 360, 6, 120);// number, r, speed, lifetime//3kf 5min
+                }
+                score =["E5","C5"];
+                s = g.beep.makeScore(score, 50, 0.5);
+                note.play(s, g.time());
+            }
+        }
+
+        let speed = 3 + status.speed;// - (this.spriteItem.slow)?1:0;
+
+        if (Boolean(this.spriteItem.slow)){ 
+            if (this.spriteItem.slow){
+                //console.log("slowtrue");
+                speed = speed/2;
+                this.spriteItem.slow = false;
+            }else{
+                this.spriteItem.slow = false;
+            }
+        }
+
+        this.r = Math.trunc(360 + this.r + x*3)%360;
+        //let vx = speed*x;
+        //let vy = speed*y;
+
+        let vx = speed * (Math.cos((Math.PI/180)*(this.r))) * -y;
+        let vy = speed * (Math.sin((Math.PI/180)*(this.r))) * -y;
+
+        console.log(this.r + ",vx" + vx + ",vy" + vy + ",x" + x + ",y" +y);
+
+        if (result.clrf && (vx==0 && vy==0)){
+            let t = g.time() - result.time
+
+            vx = (Math.abs(320 - this.x)/3 <1)?
+                Math.trunc((320 - this.x)):Math.trunc((320 - this.x)/3);
+
+            vy = (Math.abs(320 - this.y)/3 <1)?
+                Math.trunc((320 - this.y)):Math.trunc((320 - this.y)/3);
+        }
+
+        let wallf = false;
+        let wpl = Boolean(this.spriteItem.wall)?((this.spriteItem.wall)?true:false):false;
+        
+        let waf = false;
+        let wal = false;
+        let war = false;
+
+        let pup = false;
+        
+        if (this.spriteItem.living){
+            //自機が生きている状態
+            pup = Boolean(this.spriteItem.mode)?((this.spriteItem.mode !=0)?true:false):false;
+            if (pup){
+                //Powerup処理
+                if ((this.spriteItem.mode&1) != 0){
+                    if (!ArmorF.sp.living){
+                        ArmorF = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+                    }
+                }
+                if ((this.spriteItem.mode&2) != 0){
+                    if (!ArmorL.sp.living){
+                        ArmorL = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+                    }
+                    if (!ArmorR.sp.living){
+                        ArmorR = {sp:g.sprite.itemCreate("ARMOR_P", true, 32, 32), re:false};
+                    }
+                }
+                if ((this.spriteItem.mode&4) != 0){
+                    if (!Friend.sp.living){
+                        Friend = {sp:g.sprite.itemCreate("FRIEND_P", true, 32, 32) , re:false};
+                        FriendT = {sp:g.sprite.itemCreate("Turlet", false, 32, 32) , re:false};
+                    }
+                }
+                if ((this.spriteItem.mode&8) != 0){
+                    blmode = (blmode)?false:true;
+                }
+                this.spriteItem.mode =0;
+            }
+            reexf = false;//爆発済みf
+        }else{
+            if (!reexf){
+                 explose(g,
+                    this.x, this.y);
+                reexf = true;
+                MyTurlet.sp.hide();
+                if (Friend.sp.living) Friend.sp.dispose();
+                if (ArmorF.sp.living) ArmorF.sp.dispose();
+                if (ArmorL.sp.living) ArmorL.sp.dispose();
+                if (ArmorR.sp.living) ArmorR.sp.dispose();
+                blmode = false;
+            }
+        }
+
+        if (Friend.sp.living){
+            this.spriteItem.linkedOption = true;
+            //僚機が生きている状態
+        }else{
+            if (FriendT.sp.living) FriendT.sp.dispose();
+            this.spriteItem.linkedOption = false;
+        }
+
+        if (ArmorF.sp.living){
+            waf = Boolean(ArmorF.wall)?((ArmorF.wall)?true:false):false;
+            ArmorF.wall = false;
+        }
+        if (ArmorL.sp.living){
+            wal = Boolean(ArmorF.wall)?((ArmorL.wall)?true:false):false;
+            ArmorL.wall = false;
+        }
+        if (ArmorR.sp.living){
+            war = Boolean(ArmorF.wall)?((ArmorR.wall)?true:false):false;
+            ArmorR.wall = false;        
+        }
+        
+        wallf = (wpl || waf || wal || war)?true:false;
+        if (wallf){ 
+            this.x = this.old_x;
+            this.y = this.old_y;
+            this.spriteItem.wall = false;
+        }
+
+        if (reexf) return;
+
+        if (!lock) this.turlet.check(this.r);
+        if ((vx!=0 || vy!=0)||result.clrf) {
+
+            this.old_x = Math.trunc(this.x);
+            this.old_y = Math.trunc(this.y);
+
+            let tajs = (g.deltaTime()/(1000/60));//speed DeltaTime ajust 60f base
+            this.x = this.x + (vx * tajs);
+            this.y = this.y + (vy * tajs);
+
+            
+            if (this.x < 32)	this.x = 32;
+            if (this.x > RESO_X-32)	this.x = RESO_X-32;
+            if (this.y < 32)	this.y = 32;
+            if (this.y > RESO_Y-32)	this.y = RESO_Y-32;
+            
+            /*
+            if (this.x < 0)	this.x = RESO_X;
+            if (this.x > RESO_X)	this.x = 0;
+            if (this.y < 0)	this.y = RESO_Y;
+            if (this.y > RESO_Y)	this.y = 0;
+            */
+            //if (!result.clrf) this.r = this.turlet.vecToR(vx,vy);
+
+            op = this.op;
+            op.x[op.ptr] = Math.trunc(this.x);
+            op.y[op.ptr] = Math.trunc(this.y);
+            op.r[op.ptr] = this.turlet.vector();
+            op.ptr++;
+            op.ptr = op.ptr % op.x.length; 
+
+            if (g.time() > notetime) note.busy = false;
+            if ((!note.busy)&&(!result.clrf)){
+                for (let n of notescore)n.use = false;
+                //notescore[0].use = false;
+                note.play(notescore, g.time());
+                notetime = g.time() + 240;
+            }
+        }else{
+            if (input.left) this.turlet.move(-1);
+            if (input.right) this.turlet.move(1);
+        }
+
+        //g.viewport.setPos(Math.trunc(this.x-320), Math.trunc(this.y-240));
+        g.screen[0].buffer.turn(360 - this.r);//this.turlet.vector());
+    }
+    
+    this.draw = function(g){
+
+        if (Friend.sp.living){
+            for (let i=0; i < this.op.x.length - 5; i+=3){
+                let op = this.op;
+                let r = g.viewport.viewtoReal(
+                    op.x[(op.ptr + i) % op.x.length]
+                    , op.y[(op.ptr + i) % op.x.length]
+                )
+                if (r.in){
+                    g.screen[0].fill(
+                        r.x-2,
+                        r.y-2,3,3,"gray"
+                    );
+                }
+            }
+            let op = this.op;
+            Friend.sp.pos(  op.x[(op.ptr) % op.x.length], op.y[(op.ptr) % op.x.length],op.r[(op.ptr) % op.x.length]+90, 0.8);
+            FriendT.sp.pos( op.x[(op.ptr) % op.x.length], op.y[(op.ptr) % op.x.length],op.r[(op.ptr) % op.x.length]+90, 0.8);
+
+            Friend.sp.view();
+            FriendT.sp.view();
+        }else{
+            if (!Friend.re){
+                 explose(g,
+                    op.x[(op.ptr) % op.x.length]
+                    , op.y[(op.ptr) % op.x.length]
+                );
+                FriendT.sp.dispose();
+                Friend.re = true;
+            }
+        }
+
+        let tx = Math.trunc(this.x);
+        let ty = Math.trunc(this.y);
+
+        if (ArmorF.sp.living){	
+            ArmorF.sp.pos(
+                Math.trunc(tx + Math.cos((this.r)*(Math.PI/180))*20)
+                , Math.trunc(ty + Math.sin((this.r)*(Math.PI/180))*20)
+                , (this.r+90)% 360, 1);
+            ArmorF.sp.view();
+        }else{
+            if (!ArmorF.re){
+                 explose(g,
+                    tx + Math.cos((this.r)*(Math.PI/180))*20
+                    , ty + Math.sin((this.r)*(Math.PI/180))*20
+                );
+                ArmorF.re = true;
+            }
+        }
+
+        if (ArmorL.sp.living){	
+            ArmorL.sp.pos(
+                Math.trunc(tx + Math.cos((this.r-90)*(Math.PI/180))*20)
+                , Math.trunc(ty + Math.sin((this.r-90)*(Math.PI/180))*20)
+                , (this.r)% 360, 1);
+            ArmorL.sp.view();
+        }else{
+            if (!ArmorL.re){
+                 explose(g,
+                    tx + Math.cos((this.r-90)*(Math.PI/180))*16
+                    , ty + Math.sin((this.r-90)*(Math.PI/180))*16
+                );
+                ArmorL.re = true;
+            }
+        }
+
+        if (ArmorR.sp.living){	
+            ArmorR.sp.pos(
+                Math.trunc(tx + Math.cos((this.r+90)*(Math.PI/180))*17)
+                , Math.trunc(ty + Math.sin((this.r+90)*(Math.PI/180))*17)
+                , (this.r)% 360, 1);
+            ArmorR.sp.view();
+        }else{
+            if (!ArmorR.re){
+                 explose(g,
+                    Math.trunc(tx + Math.cos((this.r+90)*(Math.PI/180))*16)
+                    , Math.trunc(ty + Math.sin((this.r+90)*(Math.PI/180))*16)
+                );
+                ArmorR.re = true;
+            }
+        }
+
+        this.spriteItem.pos(tx, ty, (this.r+90)% 360, 1);
+        this.spriteItem.view();
+        if (MyTurlet.sp.living){
+            MyTurlet.sp.pos(tx, ty, (this.turlet.vector()+90)% 360, 1); 
+            MyTurlet.sp.r = (this.turlet.vector()+90)% 360;
+            MyTurlet.sp.view();
+        }
+    }
+
+    function explose(g, x, y, sr=0, w=360){
+
+        for (let r=sr; r<w; r+=(360/12)){
+            sp = g.sprite.itemCreate("BULLET_P", true, 8, 8);
+            sp.pos(x, y, r);
+            sp.move(r, 2, 30);// number, r, speed, lifetime//
+        }
+    }
+
+    function customDraw_turlet(g, screen){
+
+        let r = g.viewport.viewtoReal( this.x, this.y );
+        if (r.in){        
+            w = {x:r.x, y:r.y, c:"white", r:this.r-90
+            , draw(dev){
+                dev.beginPath();
+                //dev.fillStyle = this.c;
+                dev.globalAlpha = 1.0;
+                dev.strokeStyle = this.c;
+                dev.lineWidth = 2;
+                //dev.arc(this.x, this.y, 6, 0, 2 * Math.PI, false);
+                //dev.fill();
+                //dev.stroke();
+                dev.moveTo(this.x + Math.cos((this.r)*(Math.PI/180))*12, this.y + Math.sin((this.r)*(Math.PI/180))*12);
+                dev.lineTo(this.x + Math.cos((this.r)*(Math.PI/180))*24, this.y + Math.sin((this.r)*(Math.PI/180))*24);
+                dev.stroke();
+                } 
+            }
+            screen.putFunc(w);
+        }
+    }
+}

--- a/GameScene.js
+++ b/GameScene.js
@@ -126,12 +126,15 @@ function SceneGame(){
 
 		delay = 0;
 		trig_wait = 0;
+
+		g.screen[0].buffer.turn(0);
 	}
 	//=====
 	// Step
 	this.step = function(g, input, param){
 		stagetime = Math.trunc((g.time() - result.time)/100);
 		g.viewport.setPos(Math.trunc(320-myship.spriteItem.x), Math.trunc(240-myship.spriteItem.y));
+		//g.screen[0].buffer.turn(myship.spriteItem.r);
 
 		for (let o of GObj){
 			o.step(g, input, result);
@@ -237,6 +240,8 @@ function SceneGame(){
 				let score =["F4","E4","D4","C4","B3","B#3","C4"];
 				let s = g.beep.makeScore(score, 150, 1);
 				note[0].play(s, g.time());
+
+				g.screen[0].buffer.turn(0);
 			}
 		}
 
@@ -444,6 +449,8 @@ function SceneGame(){
 
 		let wdt = watchdog.check();
 
+		stageCtrl.draw(g);
+
 		const vp = g.viewport.viewtoReal;
 		//　FIRE DRAW 
 		if (true){
@@ -467,7 +474,7 @@ function SceneGame(){
 			}
 		}
 
-		stageCtrl.draw(g);
+		//stageCtrl.draw(g);
 
 		if (!result.govf){
 

--- a/GameScene.js
+++ b/GameScene.js
@@ -133,7 +133,8 @@ function SceneGame(){
 	// Step
 	this.step = function(g, input, param){
 		stagetime = Math.trunc((g.time() - result.time)/100);
-		g.viewport.setPos(Math.trunc(320-myship.spriteItem.x), Math.trunc(240-myship.spriteItem.y));
+		//ここでviewportの基準座標を変える事でスクロールを実現している。↓
+		//g.viewport.setPos(Math.trunc(320-myship.spriteItem.x), Math.trunc(240-myship.spriteItem.y));
 		//g.screen[0].buffer.turn(myship.r);
 
 		for (let o of GObj){

--- a/GameScene.js
+++ b/GameScene.js
@@ -101,7 +101,7 @@ function SceneGame(){
 		GObj = [];
 		g.sprite.itemFlash();
 
-		myship = new GameObject();
+		myship = new GameObjectPlayer();
 		myship.spriteItem = g.sprite.itemCreate("Player", true, 28, 28);
 		myship.spriteItem.pos(320,320);
 		myship.init(g);
@@ -134,7 +134,7 @@ function SceneGame(){
 	this.step = function(g, input, param){
 		stagetime = Math.trunc((g.time() - result.time)/100);
 		g.viewport.setPos(Math.trunc(320-myship.spriteItem.x), Math.trunc(240-myship.spriteItem.y));
-		//g.screen[0].buffer.turn(myship.spriteItem.r);
+		//g.screen[0].buffer.turn(myship.r);
 
 		for (let o of GObj){
 			o.step(g, input, result);

--- a/GameTaskMain.js
+++ b/GameTaskMain.js
@@ -33,6 +33,10 @@ class GameTask_Main extends GameTask {
 		this.scene[	"Title"	] = new SceneTitle();
 		this.scene[	"Gpad"	] = new SceneGPad();
 		this.scene[	"VGpad"	] = new SceneVGPad();
+
+		g.sprite.useScreen(0);
+		g.kanji.useScreen(0);
+		g.font["std"].useScreen(1);
 		
  	    //g.font["8x8white"].useScreen(1);
 	    g.sprite.setPattern("Player", { image: "SPGraph",

--- a/SceneCollection.js
+++ b/SceneCollection.js
@@ -32,8 +32,8 @@ function SceneGameUI(){
 		//g.font["std"].putchr("PLAYER:" + ene.now + " STAGE:" + result.stage, X, Y);
 	
 		let st="";for (let i=1; i<ene.now;i++)st+="▲";
-		g.kanji.print("PLAYER:" + st, X, Y);
-		g.kanji.print("STAGE :" + result.stage + " SCORE:" + Math.trunc(result.score),  X, Y+8);
+		g.font["std"].putchr("PLAYER:" + st, X, Y);
+		g.font["std"].putchr("STAGE :" + result.stage + " SCORE:" + Math.trunc(result.score),  X, Y+8);
 		//g.kanji.print("強化：[正面][側面][僚機]", X, Y+16);
 
 		//g.kanji.print("　　　[||| ][||| ][||| ][||| ][||| ]", X, Y+24);

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ function main() {
 		canvasId: "layer0",
         screen: [ 
 			{ resolution: { w: 640, h: 480 , x:0, y:0 } }
+            ,{ resolution: { w: 640, h: 480 , x:0, y:0 } }
         ]
 	}
 	const game = new GameCore( sysParam );

--- a/offScreenTypeC.js
+++ b/offScreenTypeC.js
@@ -37,6 +37,7 @@ context.drawImage(offscreenCanvas, 0, 0);
     let enable_draw_flag = true;
     let enable_reset_flag = true;
 
+    let _2DEffectEnable = false;//事前にオンしないと効果が動作しない(DEBUG)
     let view_angle = 0;
 
     this.view = function ( flg ){ //flg : bool
@@ -54,7 +55,12 @@ context.drawImage(offscreenCanvas, 0, 0);
     }
     //2024/04/29 new Function turn
     this.turn = function( r ){
-        view_angle = r;
+        if  (_2DEffectEnable) 
+            view_angle = r;
+    }
+
+    this._2DEF = function(f){
+        _2DEffectEnable = f
     }
 
     //this.flip = function ( outdev ) {

--- a/offScreenTypeC.js
+++ b/offScreenTypeC.js
@@ -1,0 +1,254 @@
+﻿
+// offScreenクラス
+// (offscreen buffer)
+//
+// offScreenCanvasに随時描画
+//(Chrome69＿Sep.2018でサポートとの事なので対応
+//
+//一度作成したらあまり書き換えないといった使い方をする場合に良い
+//UIを作成したあとにフレーム毎ではなく必要時書き換えで使うとか
+//全画面表示したいので表示はキャンバスを重ねないようにする
+//(mainのCanvasに全部表示させる）
+
+function offScreenTypeC( w, h, ix, iy ){//typeOffscreenCanvas版
+    //w : width, h:height
+    const element = new OffscreenCanvas( w, h );
+
+    const offset_x = ix;
+    const offset_y = iy;
+/*
+const offscreenCanvas = new OffscreenCanvas(200, 200);
+const offscreenContext = offscreenCanvas.getContext('2d');
+offscreenContext.fillStyle = 'red';
+offscreenContext.fillRect(0, 0, 200, 200);
+
+const canvas = document.getElementById('canvas');
+const context = canvas.getContext('2d');
+context.drawImage(offscreenCanvas, 0, 0);
+*/
+//2018頃にOFFSCREENcanvasが実装されたみたいなのでOFFSCREENCとして実装
+
+    //var element = document.createElement("canvas");
+    element.width = w;
+    element.height = h;
+
+    const device = element.getContext("2d");
+
+    let enable_draw_flag = true;
+    let enable_reset_flag = true;
+
+    let view_angle = 0;
+
+    this.view = function ( flg ){ //flg : bool
+        if (typeof flg == "boolean") {
+            enable_draw_flag = flg;
+        }
+        return enable_draw_flag;
+    }
+
+    this.flip = function( flg ){
+        if (typeof flg == "boolean") {
+            enable_reset_flag = flg;
+        }
+        return enable_draw_flag;
+    }
+    //2024/04/29 new Function turn
+    this.turn = function( r ){
+        view_angle = r;
+    }
+
+    //this.flip = function ( outdev ) {
+
+    //    outdev.putImageData(device.getImageData(0, 0, element.width, element.height), 0, 0);
+    //}
+
+    //-------------------------------------------------------------
+    //SP_PUT
+    //use img, sx, sy, sw, sh, dx, dy, dw, dh, m11, m12, m21, m22, tx, ty, alpha, r
+    //-------------------------------------------------------------
+    this.spPut = function (img, sx, sy, sw, sh, dx, dy, dw, dh, m11, m12, m21, m22, tx, ty, alpha, r) {
+
+        device.save();
+
+        device.setTransform(m11, m12, m21, m22, tx, ty);
+        if (r != 0) { device.rotate(Math.PI / 180 * r); }
+
+        if (alpha == 255) {
+            device.globalCompositeOperation = "source-over";
+        } else {
+            //if (this.light_enable) device.globalCompositeOperation = "lighter"; //source-over
+            device.globalAlpha = alpha * (1.0 / 255);
+        }
+
+        device.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
+
+        device.restore();
+    }
+
+    //-------------------------------------------------------------
+    //DRAWIMG_XYWH_XYWH
+    //use img, sx, sy, sw, sh, dx, dy, dw, dh
+    //-------------------------------------------------------------
+    this.drawImgXYWHXYWH = function (img, sx, sy, sw, sh, dx, dy, dw, dh) {
+
+        device.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh);
+    }
+
+    //-------------------------------------------------------------
+    //FILLTEXT
+    //use text, sx, sy, color
+    //-------------------------------------------------------------
+    this.fillText = function (str, x, y, c) {
+
+        if (!Boolean(c)) { c = "limegreen"; }
+
+        device.fillStyle = c;
+        device.fillText(str, x, y);
+    }
+   
+    //------------------------------------------------------------
+    //DRAWIMG_XY
+    //use img, sx, sy, sw, sh
+    //------------------------------------------------------------
+    this.drawImgXY = function (img, sx, sy) {
+        
+        device.drawImage(img, sx, sy);
+    }
+
+    //------------------------------------------------------------
+    //DRAWIMG_XYWH
+    //use img, sx, sy, sw, sh
+    //------------------------------------------------------------
+    this.drawImgXYWH = function (img, sx, sy, sw, sh) {
+
+        device.drawImage(img, sx, sy, sw, sh);
+    }
+
+    //------------------------------------------------------------
+    //PUTIMAGETRANSFORM
+    //use img, m11, m12, m21, m22, tx, ty
+    //------------------------------------------------------------
+    this.putImageTransform = function (img, x, y, m11, m12, m21, m22) {
+
+        device.save();
+
+        device.setTransform(m11, m12, m21, m22, x, y);
+        device.drawImage(img, 0, 0);
+
+        device.restore();
+    }
+
+    //---------------------------------------------------------
+    //TRANSFORM
+    //use m11, m12, m21, m22, tx, ty
+    //---------------------------------------------------------
+    this.transform = function (m11, m12, m21, m22) {
+        //dummy
+    }
+
+    //------------------------------------------------------------
+    // クラスで表示コマンドを登録して表示させる。
+    // 引数 cl:class
+    //------------------------------------------------------------
+    this.putFunc = function (cl) {
+
+        cl.draw(device);
+        //ここで登録するクラスには表示の為に"draw( device )" functionを必ず登録
+    }
+
+    //---------------------------------------------------------
+    //ALLCLEAR
+    //use sx, sy, sw, sh
+    //---------------------------------------------------------
+    this.allClear = function (sx, sy, sw, sh) {
+
+        device.save();
+
+        device.setTransform(1, 0, 0, 1, 0, 0);
+        device.clearRect(sx, sy, sw, sh);
+
+        device.restore();
+    }
+
+    //-----------------------------------------------------
+    //FILLRECT
+    //use sx, sy, sw, sh, color
+    //----------------------------------------------------
+    this.fillRect = function (sx, sy, sw, sh, color) {
+
+        if (Boolean(color)) {
+            device.fillStyle = color;
+            device.fillRect(sx, sy, sw, sh);
+        } else {
+            device.clearRect(sx, sy, sw, sh);
+        }
+    }
+
+    //----------------------------------------------------------
+    //描画バッファ配列のリセット(offScreenバッファのクリア)
+    //----------------------------------------------------------
+    this.reset = function () {
+
+        if (enable_reset_flag){
+            this.allClear(0, 0, w, h);
+        }
+    }
+
+    //----------------------------------------------------------
+    //(flameloopで実行用）offScreenバッファのクリア
+    //----------------------------------------------------------
+    this.reflash = function () {
+
+        if (enable_reset_flag){
+            this.reset();
+        }
+    }
+
+    //----------------------------------------------------------
+    //描画
+    //----------------------------------------------------------
+    this.draw = function ( outdev ) {
+        //2024/04/29 new Function turn
+        if (enable_draw_flag){
+            if (view_angle == 0){ 
+                //outdev.clearRect(x, y, w, h);
+                outdev.drawImage(element, offset_x, offset_y);
+            }else{
+                let w = element.width;
+                let h = element.height;
+                
+                outdev.save();
+                outdev.translate(w/2,h/2);
+                outdev.rotate((Math.PI/180)*(view_angle+270)%360);
+                
+                outdev.drawImage(element, -w/2, -h/2);
+                //outdev.drawImage(element, offset_x, offset_y);
+
+                outdev.restore();
+                console.log("e" + view_angle%360);
+            }
+        }
+    }
+    //----------------------------------------------------------
+    //
+    //----------------------------------------------------------
+    this.count = function () {
+        //dummy
+        return "mode";
+    }
+
+    //----------------------------------------------------------
+    //
+    //----------------------------------------------------------
+    this.max = function () {
+        //dummy
+        return "C";
+    }
+
+
+
+    //
+}
+
+
+

--- a/offScreenTypeC.js
+++ b/offScreenTypeC.js
@@ -12,7 +12,7 @@
 
 function offScreenTypeC( w, h, ix, iy ){//typeOffscreenCanvas版
     //w : width, h:height
-    const element = new OffscreenCanvas( w, h );
+    const element = new OffscreenCanvas( w*2, h*2 );
 
     const offset_x = ix;
     const offset_y = iy;
@@ -211,7 +211,7 @@ context.drawImage(offscreenCanvas, 0, 0);
         //2024/04/29 new Function turn
         if (enable_draw_flag){
             if (view_angle == 0){ 
-                //outdev.clearRect(x, y, w, h);
+                //outdev.clearRect(0, 0, w, h);
                 outdev.drawImage(element, offset_x, offset_y);
             }else{
                 let w = element.width;
@@ -225,7 +225,7 @@ context.drawImage(offscreenCanvas, 0, 0);
                 //outdev.drawImage(element, offset_x, offset_y);
 
                 outdev.restore();
-                console.log("e" + view_angle%360);
+                //console.log("e" + view_angle%360);
             }
         }
     }


### PR DESCRIPTION
背景の回転機能追加の為の改良実験
-----
   -  offscreenCanvas部分はまだ調整中だが機能のオンオフを可能としたので動作はmain版と同様となもる。
   -  回転させるとクリア表示、残機やスコア表示も回転する為、レイヤー分離　[0]背景[、[1]ASCII文字面

現状は表示解像度と内部解像度が同じなので回転させると枠外が残って表示が乱れるのでオフにしている。
Todo)　内部解像度を倍にして処理することをにする。処理側を変更せずにすむように書き込み座標補正を自動でやること

左右回転、前後移動の操作パターンのプレイヤーとしている
